### PR TITLE
Remove the RTOS thread size optimizations

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -16,8 +16,6 @@
             "platform.stdio-buffered-serial"            : true,
             "platform.stdio-flush-at-exit"              : true,
             "rtos.main-thread-stack-size"               : 5120,
-            "rtos.timer-thread-stack-size"              : 256,
-            "rtos.idle-thread-stack-size"               : 256,
             "update-client.storage-locations"           : 1,
             "mbed-trace.enable"                         : null,
             "events.shared-stacksize"                   : 2048,


### PR DESCRIPTION
These might not be very good anymore with 5.14. Better remove them from here and instead optimize Mbed OS if needed.