### PR TITLE
Update deregister test code.

### DIFF
--- a/TESTS/deregister.py
+++ b/TESTS/deregister.py
@@ -46,7 +46,8 @@ class Testcase(PelionBase):
 
         # Verify client is deregistered
         self.logger.info("POST done")
-
+        # Post response may comes fast. Wait finish deregister operation
+        self.delay(5)
         self.verify_registration("deregistered")
 
     def teardown(self):


### PR DESCRIPTION
Deregister response may comes super fast, (before finish client_close operation) which lead to test fail.
Add 5 seconds delay to avoid that.