### PR TITLE
Add flush of the STDIN buffer and reset EP_AGORA baud to default

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -120,6 +120,15 @@ void update_progress(uint32_t progress, uint32_t total)
     printf("Update progress = %" PRIu8 "%%\n", percent);
 }
 
+void flush_stdin_buffer(void)
+{
+    FileHandle *debug_console = mbed::mbed_file_handle(STDIN_FILENO);
+    while(debug_console->readable()) {
+        char buffer[1];
+        debug_console->read(buffer, 1);
+    }
+}
+
 int main(void)
 {
     int status;
@@ -236,6 +245,9 @@ int main(void)
 
     t.start(callback(&queue, &EventQueue::dispatch_forever));
     queue.call_every(5000, value_increment);
+
+    // Flush the stdin buffer before reading from it
+    flush_stdin_buffer();
 
     while(cloud_client_running) {
         int in_char = getchar();

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -288,8 +288,6 @@
             "storage_filesystem.blockdevice"            : "SPIF",
             "storage_filesystem.external_base_address"  : "(0x0)",
             "storage_filesystem.external_size"          : "(1024*1024*1)",
-            "platform.default-serial-baud-rate"         : 230400,
-            "platform.stdio-baud-rate"                  : 230400,
             "drivers.uart-serial-rxbuf-size"            : 1024,
             "drivers.uart-serial-txbuf-size"            : 1024,
             "lwip.ipv4-enabled"                         : true,


### PR DESCRIPTION
The `EP_AGORA` target was suffering from an issue where unwanted serial data was being read on the debug UART. So, when the application hits the call to `getchar()` in the main while loop, it'd hit one of the command characters ('r', or 'i') and cause unwanted behavior.

In order to work around this, I've added a call to a new function (`flush_stdin_buffer()`) which simply reads out the receive buffer of the debug UART character by character until it's empty and throws it away before hitting the main while loop. This results in the issue being resolved on the `EP_AGORA` target and is generally a good way to prevent any unwanted serial input on any target.