### PR TITLE
Update Pelion E2E test library to 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Board                          |  Connectivity     | Storage for credentials and
 `ST NUCLEO_F429ZI`                  | Ethernet          | Internal Flash          |
 `ST NUCLEO_F411RE`                  | Wi-Fi ESP8266     | SD card                 |
 `Ublox UBLOX_EVK_ODIN_W2`           | Wi-Fi             | SD card                 |
-`ST DISCO_L475VG_IOT01A`            | Wi-Fi             | QSPIF                   |
+`ST DISCO_L475VG_IOT01A`            | Wi-Fi             | QSPIF                   | Build-only
 `Ublox UBLOX_C030_U201`             | Cellular          | SD card                 | Build-only
 `Ublox UBLOX_C030_R412M`            | Cellular          | SD card                 | Build-only
 `Embedded Planet EP_AGORA`          | Cellular          | SPIF                    | Build-only

--- a/TESTS/pelion-e2e-python-test-library.lib
+++ b/TESTS/pelion-e2e-python-test-library.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/pelion-e2e-python-test-library/#1d0fe93aa5f498802ec8d8f065af62bcef0ba38c
+https://github.com/ARMmbed/pelion-e2e-python-test-library/#772b9d52c34c0fa6ce42331075460e9df1560de8

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -264,8 +264,7 @@
             "update-client.firmware-header-version"     : "2",
             "update-client.storage-address"             : "(MBED_CONF_STORAGE_FILESYSTEM_EXTERNAL_BASE_ADDRESS + MBED_CONF_STORAGE_FILESYSTEM_EXTERNAL_SIZE)",
             "update-client.storage-locations"           : 1,
-            "update-client.storage-size"                : "((MBED_ROM_START + MBED_ROM_SIZE - APPLICATION_ADDR) * MBED_CONF_UPDATE_CLIENT_STORAGE_LOCATIONS)",
-            "run-ci"                                    : 2
+            "update-client.storage-size"                : "((MBED_ROM_START + MBED_ROM_SIZE - APPLICATION_ADDR) * MBED_CONF_UPDATE_CLIENT_STORAGE_LOCATIONS)"
         },
         "EP_AGORA": {
             "target.features_remove"                    : ["BLE", "CRYPTOCELL310"],


### PR DESCRIPTION
This brings in two new tests

- test_05_factory_reset
- test_06_update_device

Other changes:
- disable DISCO_L475VG_IOT01A due to active image corruption in E2E testing while the issue is being investigated