### PR TITLE
fix comment for factory reset, should be /3/0/5

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -226,7 +226,7 @@ int main(void)
         return -1;
     }
 
-    // optional Device resource for running factory reset for the device. Path of this resource will be: 3/0/6.
+    // optional Device resource for running factory reset for the device. Path of this resource will be: 3/0/5.
     m2m_factory_reset_res = M2MInterfaceFactory::create_device()->create_resource(M2MDevice::FactoryReset);
     if (m2m_factory_reset_res) {
         m2m_factory_reset_res->set_execute_function(factory_reset);


### PR DESCRIPTION
### Summary of changes <!-- Required -->

misleading comment for factory reset, should be '/3/0/5' instead of '/3/0/6'

<!--

For more information on the requirements for pull requests, please see [the CONTRIBUTING.md](CONTRIBUTING.md).

-->

[X] I confirm this contribution is my own and I agree to license it with Apache 2.0.

[X] I confirm the moderators may change the PR before merging it in.

For new board enablements only:

[] I confirm the board is [Mbed Enabled](https://www.mbed.com/en/about-mbed/mbed-enabled/introduction/) and passes the Mbed Enabled test set.

[] I confirm the contribution has been tested properly and the tests results for [TESTS](https://github.com/ARMmbed/mbed-os-example-pelion/tree/master/TESTS) are attached.

[] I confirm `mbed-os.lib` and `mbed-cloud-client.lib` hashes or the content in folders `mbed-os` and `mbed-cloud-client` were not modified in order to pass the tests.

- Maintainers of this repository update the Mbed OS and Client hashes.
- Please report any issues through issues in relevant repositories.
