### PR TITLE
Reset device if it gets numerous connection errors

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -100,7 +100,6 @@ void client_registered(void)
 void client_registration_updated(void)
 {
     printf("Client registration updated.\n");
-    print_client_ids();
     error_count = 0;
 }
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->
This PR adds a reset of the device if multiple networking errors are encountered without re-registration. The functionality is useful in situations when the network stack or the network itself is unstable.

[x] I confirm this contribution is my own and I agree to license it with Apache 2.0.

[x] I confirm the moderators may change the PR before merging it in.

For new board enablements only:

[] I confirm the board is [Mbed Enabled](https://www.mbed.com/en/about-mbed/mbed-enabled/introduction/) and passes the Mbed Enabled test set.

[] I confirm the contribution has been tested properly and the tests results for [TESTS](https://github.com/ARMmbed/mbed-os-example-pelion/tree/master/TESTS) are attached.

[] I confirm `mbed-os.lib` and `mbed-cloud-client.lib` hashes or the content in folders `mbed-os` and `mbed-cloud-client` were not modified in order to pass the tests.

- Maintainers of this repository update the Mbed OS and Client hashes.
- Please report any issues through issues in relevant repositories.
