### PR TITLE
Update to Device Management Client 4.4.0

### DIFF
--- a/TESTS/pelion-e2e-python-test-library.lib
+++ b/TESTS/pelion-e2e-python-test-library.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/pelion-e2e-python-test-library/#4a3a533f8b2115e11ec412974e0d45b008ccc095
+https://github.com/ARMmbed/pelion-e2e-python-test-library/#39e118e03dc89f1800922f3a91d219b25c45cb1a

--- a/main.cpp
+++ b/main.cpp
@@ -200,6 +200,15 @@ int main(void)
         return -1;
     }
 
+#ifdef MBED_CLOUD_CLIENT_SUPPORT_UPDATE
+    cloud_client = new MbedCloudClient(client_registered, client_unregistered, client_error, NULL, update_progress);
+#else
+    cloud_client = new MbedCloudClient(client_registered, client_unregistered, client_error);
+#endif // MBED_CLOUD_CLIENT_SUPPORT_UPDATE
+
+    // Initialize client
+    cloud_client->init();
+
     printf("Create resources\n");
     M2MObjectList m2m_obj_list;
 
@@ -251,12 +260,6 @@ int main(void)
     }
 
     printf("Register Pelion Device Management Client\n\n");
-
-#ifdef MBED_CLOUD_CLIENT_SUPPORT_UPDATE
-    cloud_client = new MbedCloudClient(client_registered, client_unregistered, client_error, NULL, update_progress);
-#else
-    cloud_client = new MbedCloudClient(client_registered, client_unregistered, client_error);
-#endif // MBED_CLOUD_CLIENT_SUPPORT_UPDATE
 
     cloud_client->on_registration_updated(client_registration_updated);
 

--- a/mbed-cloud-client.lib
+++ b/mbed-cloud-client.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-cloud-client/#7b583acf30ca142c1949149c90bba420cd467b63
+https://github.com/ARMmbed/mbed-cloud-client/#e03c516af9c9137b56d9c2620a293c79f1f867f8


### PR DESCRIPTION
Bring in [4.4.0](https://github.com/ARMmbed/mbed-cloud-client/releases/tag/4.4.0) release of Device Management Client.

Also bring in new version of Pelion E2E test library.

```
2020-04-21 13:51:47.446      INFO   -----  TEST RESULTS SUMMARY  -----
2020-04-21 13:51:47.447      INFO   [passed] - dev-client-tests.py::test_01_get_device_id - (0.938s)
2020-04-21 13:51:47.447      INFO   [passed] - dev-client-tests.py::test_02_get_resource - (9.857s)
2020-04-21 13:51:47.447      INFO   [passed] - dev-client-tests.py::test_03_put_resource - (1.839s)
2020-04-21 13:51:47.447      INFO   [passed] - dev-client-tests.py::test_04_subscribe_resource - (4.107s)
2020-04-21 13:51:47.448      INFO   [passed] - dev-client-tests.py::test_05_factory_reset - (22.610s)
2020-04-21 13:51:47.448      INFO   [passed] - dev-client-tests.py::test_06_update_device - (176.397s)
```