### PR TITLE
Remove unsupported STM32 EMAC configuration

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -29,10 +29,6 @@
         "Freescale": {
             "lwip.mem-size"                             : 12500
         },
-        "STM_EMAC": {
-            "lwip.pbuf-pool-size"                       : 16,
-            "lwip.mem-size"                             : 12500
-        },
         "K64F": {
             "target.macros_add"                         : ["MBEDTLS_USER_CONFIG_FILE=\"mbedTLSConfig_mbedOS.h\""],
             "target.network-default-interface-type"     : "ETHERNET",


### PR DESCRIPTION
This has been removed in Mbed OS 5.14.2

https://github.com/ARMmbed/mbed-cloud-client-example/issues/65

