### PR TITLE
Fix compilation error - psoc PinNames.h collide with functionpointer.h

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -16,14 +16,14 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------
 #ifndef MBED_TEST_MODE
-#include "mbed.h"
-#include "DeviceKey.h"
-#include "kv_config.h"
 #include "mbed-cloud-client/MbedCloudClient.h" // Required for new MbedCloudClient()
 #include "factory_configurator_client.h"       // Required for fcc_* functions and FCC_* defines
 #include "m2mresource.h"                       // Required for M2MResource
 #include "key_config_manager.h"                // Required for kcm_factory_reset
 
+#include "mbed.h"
+#include "DeviceKey.h"
+#include "kv_config.h"
 #include "mbed-trace/mbed_trace.h"             // Required for mbed_trace_*
 
 // Pointers to the resources that will be created in main_application().


### PR DESCRIPTION
Both use `A1` symbol.
```
./mbed-os/targets/TARGET_Cypress/TARGET_PSOC6/PinNames.h:145:12: note: in expansion of macro 'CYBSP_A1'
  145 | #define A1 CYBSP_A1
      |            ^~~~~~~~
./mbed-cloud-client/mbed-client/mbed-client/functionpointer.h:112:32: note: in expansion of macro 'A1'
  112 | template <typename R, typename A1>
      |                                ^~
```
Also, remove a warning from call to `sleep_for`.

### Summary of changes <!-- Required -->

<!--
    Please provide the following information:

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed, add references to issues if this is a fix.

    Avoid too large commits. Each commit should be an atomic, independent change.

    Write good, descriptive Git commit messages.

-->

<!--

For more information on the requirements for pull requests, please see [the CONTRIBUTING.md](CONTRIBUTING.md).

-->

[x] I confirm this contribution is my own and I agree to license it with Apache 2.0.

[x] I confirm the moderators may change the PR before merging it in.

For new board enablements only:

[] I confirm the board is [Mbed Enabled](https://www.mbed.com/en/about-mbed/mbed-enabled/introduction/) and passes the Mbed Enabled test set.

[] I confirm the contribution has been tested properly and the tests results for [TESTS](https://github.com/ARMmbed/mbed-os-example-pelion/tree/master/TESTS) are attached.

[] I confirm `mbed-os.lib` and `mbed-cloud-client.lib` hashes or the content in folders `mbed-os` and `mbed-cloud-client` were not modified in order to pass the tests.

- Maintainers of this repository update the Mbed OS and Client hashes.
- Please report any issues through issues in relevant repositories.
