### PR TITLE
Fix m2m_deregister_res typo in printf

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -256,7 +256,7 @@ int main(void)
     m2m_deregister_res->set_delayed_response(true);
 
     if (m2m_deregister_res->set_execute_function(deregister) != true) {
-        printf("m2m_post_res->set_execute_function() failed\n");
+        printf("m2m_deregister_res->set_execute_function() failed\n");
         return -1;
     }
 


### PR DESCRIPTION
### Summary of changes <!-- Required -->

<!--
    Please provide the following information:

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed, add references to issues if this is a fix.

    Avoid too large commits. Each commit should be an atomic, independent change.

    Write good, descriptive Git commit messages.

-->

Just a simple typo fix in a print for the m2m_deregister_res resource.

<!--

For more information on the requirements for pull requests, please see [the CONTRIBUTING.md](CONTRIBUTING.md).

-->

[X] I confirm this contribution is my own and I agree to license it with Apache 2.0.

[X] I confirm the moderators may change the PR before merging it in.

For new board enablements only:

[] I confirm the board is [Mbed Enabled](https://www.mbed.com/en/about-mbed/mbed-enabled/introduction/) and passes the Mbed Enabled test set.

[] I confirm the contribution has been tested properly and the tests results for [TESTS](https://github.com/ARMmbed/mbed-os-example-pelion/tree/master/TESTS) are attached.

[] I confirm `mbed-os.lib` and `mbed-cloud-client.lib` hashes or the content in folders `mbed-os` and `mbed-cloud-client` were not modified in order to pass the tests.

- Maintainers of this repository update the Mbed OS and Client hashes.
- Please report any issues through issues in relevant repositories.
