### PR TITLE
Fix wrong print of `Endpoint name` and `Device ID`

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -50,8 +50,8 @@ Mutex value_increment_mutex;
 void print_client_ids(void)
 {
     printf("Account ID: %s\n", cloud_client->endpoint_info()->account_id.c_str());
-    printf("Endpoint name: %s\n", cloud_client->endpoint_info()->internal_endpoint_name.c_str());
-    printf("Device ID: %s\n\n", cloud_client->endpoint_info()->endpoint_name.c_str());
+    printf("Endpoint name: %s\n", cloud_client->endpoint_info()->endpoint_name.c_str());
+    printf("Device ID: %s\n\n", cloud_client->endpoint_info()->internal_endpoint_name.c_str());
 }
 
 void value_increment(void)


### PR DESCRIPTION
Fix a wrong print of `Endpoint name` and `Device ID` when using production flow.
For developer flow, `Endpoint name` and `Device ID` are equal

### Summary of changes <!-- Required -->

<!--
    Please provide the following information:

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed, add references to issues if this is a fix.

    Avoid too large commits. Each commit should be an atomic, independent change.

    Write good, descriptive Git commit messages.

-->

<!--

For more information on the requirements for pull requests, please see [the CONTRIBUTING.md](CONTRIBUTING.md).

-->

[x] I confirm this contribution is my own and I agree to license it with Apache 2.0.

[x] I confirm the moderators may change the PR before merging it in.

For new board enablements only:

[] I confirm the board is [Mbed Enabled](https://www.mbed.com/en/about-mbed/mbed-enabled/introduction/) and passes the Mbed Enabled test set.

[] I confirm the contribution has been tested properly and the tests results for [TESTS](https://github.com/ARMmbed/mbed-os-example-pelion/tree/master/TESTS) are attached.

[] I confirm `mbed-os.lib` and `mbed-cloud-client.lib` hashes or the content in folders `mbed-os` and `mbed-cloud-client` were not modified in order to pass the tests.

- Maintainers of this repository update the Mbed OS and Client hashes.
- Please report any issues through issues in relevant repositories.
