### PR TITLE
Updating link to Cypress documentation from main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This table shows a list of boards that are supported.
 
 Board                               |  Connectivity     | Storage for credentials and FW candidate | Notes
 ------------------------------------| ------------------| ------------------------| --------------
-Cypress `CYTFM_064B0S2_4343W`       | Wi-Fi             | Internal flash for credentials + external flash for FW candidate | To use `mbed-cloud-client-example` with the `CYTFM_064B0S2_4343W` board, please check out the [cytfm-064b0s2-4343w](../cytfm-064b0s2-4343w/TARGET_CYTFM_064B0S2_4343W/README.md) branch.
+Cypress `CYTFM_064B0S2_4343W`       | Wi-Fi             | Internal flash for credentials + external flash for FW candidate | To use `mbed-cloud-client-example` with the `CYTFM_064B0S2_4343W` board, please check out the `cytfm-064b0s2-4343w` branch and see the [*Running Device Management Client example on the CYTFM_064B0S2_4343W* document](../cytfm-064b0s2-4343w/TARGET_CYTFM_064B0S2_4343W/README.md).
 Cypress `CY8CPROTO-062-4343W`       | Wi-Fi             | QSPIF                   | Build-only
 Embedded Planet `EP_AGORA`          | Cellular          | SPIF                    | Build-only
 Nuvoton `NUMAKER_IOT_M263A`         | Wi-Fi ESP8266     | SD card (NUSD)          | Build-only


### PR DESCRIPTION
### Summary of changes 

Clarifying text that links to documentation from main README in the branch.

[x] I confirm this contribution is my own and I agree to license it with Apache 2.0.

[x] I confirm the moderators may change the PR before merging it in.

- Maintainers of this repository update the Mbed OS and Client hashes.
- Please report any issues through issues in relevant repositories.
