### PR TITLE
Use c_lib std by default

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -10,6 +10,7 @@
     "target_overrides": {
         "*": {
             "target.features_add"                       : ["BOOTLOADER", "STORAGE"],
+            "target.c_lib"                              : "std",
             "platform.stdio-baud-rate"                  : 115200,
             "platform.stdio-convert-newlines"           : true,
             "platform.stdio-buffered-serial"            : true,


### PR DESCRIPTION
All targets use standard C libraries instead of the small C libraries. This prevents potential issues with certain drivers that may have dependencies on `c_lib` implementation.

### Summary of changes <!-- Required -->

<!--
    Please provide the following information:

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed, add references to issues if this is a fix.

    Avoid too large commits. Each commit should be an atomic, independent change.

    Write good, descriptive Git commit messages.

-->

<!--

For more information on the requirements for pull requests, please see [the CONTRIBUTING.md](CONTRIBUTING.md).

-->

[] I confirm this contribution is my own and I agree to license it with Apache 2.0.

[] I confirm the moderators may change the PR before merging it in.

For new board enablements only:

[] I confirm the board is [Mbed Enabled](https://www.mbed.com/en/about-mbed/mbed-enabled/introduction/) and passes the Mbed Enabled test set.

[] I confirm the contribution has been tested properly and the tests results for [TESTS](https://github.com/ARMmbed/mbed-os-example-pelion/tree/master/TESTS) are attached.

[] I confirm `mbed-os.lib` and `mbed-cloud-client.lib` hashes or the content in folders `mbed-os` and `mbed-cloud-client` were not modified in order to pass the tests.

- Maintainers of this repository update the Mbed OS and Client hashes.
- Please report any issues through issues in relevant repositories.
